### PR TITLE
Fix Setup Ballerina Action on Windows for "latest" Version and Test Workflows Version Handling

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set env
         run: |-
           echo "balVersion=$(
-          if [[${{ github.event.inputs.balVersion }}]]; then
+          if [[ -n "${{ github.event.inputs.balVersion }}" ]]; then
             echo ${{ github.event.inputs.balVersion }}
           else
             echo 2201.3.2

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set env
         run: |-
           echo "balVersion=$(
-          if [[${{ github.event.inputs.balVersion }}]]; then
+          if [[ -n "${{ github.event.inputs.balVersion }}" ]]; then
             echo ${{ github.event.inputs.balVersion }}
           else
             echo 2201.3.2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set env
         run: |-
           echo "balVersion=$(
-          if [[${{ github.event.inputs.balVersion }}]]; then
+          if [[ -n "${{ github.event.inputs.balVersion }}" ]]; then
             echo ${{ github.event.inputs.balVersion }}
           else
             echo 2201.3.2

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
           set -x
           if [[ $OSTYPE == 'msys'* ]]; then
             echo "windows runner detected"
-            msiexec //i ballerina-${{ steps.configure-version.outputs.version }}-swan-lake-windows-x64.msi //qn
+            msiexec //i ballerina-${{ inputs.version }}-swan-lake-windows-x64.msi //qn
             echo "BALLERINA_HOME=C:\\Program Files\\Ballerina\\" >> $GITHUB_ENV
             powershell ${GITHUB_ACTION_PATH}/updatepath.ps1    
           elif [[ $OSTYPE == 'darwin'* ]]; then


### PR DESCRIPTION
## Purpose

This pull request addresses two issues with the setup-ballerina action:

- Issue with "latest" version: Currently, the action fails when `version: latest` is provided in Windows workflows due to a configuration error related to [issue #6](https://github.com/ballerina-platform/setup-ballerina/issues/6#issue-2209828009).
- Test workflow configurations: The test workflows for the action have a misconfiguration that causes them to fall back to the default version instead of using the specified version when triggered with workflow dispatch actions.

## Goals
- Fix Windows action workflow when the 'latest' flag is provided.
- Fix workflow test configurations to use the defined version instead of the default version when workflow dispatch actions are triggered with the specified version.

## Approach
- Changing the [steps.configure-version.outputs.version](https://github.com/ballerina-platform/setup-ballerina/blob/main/action.yml#L54C39-L54C78) to [inputs.version](https://github.com/ballerina-platform/setup-ballerina/blob/main/action.yml#L39C216-L39C230) fixes the windows action to run with the `latest` flag.

- Changing the conditional logic from [{{ github.event.inputs.balVersion }}](https://github.com/ballerina-platform/setup-ballerina/blob/main/.github/workflows/test-windows.yml#L19C14-L19C55) to `-n "${{ github.event.inputs.balVersion }}"` fixes the test workflows to run correctly.