### PR TITLE
Fix deprecated command and actions usage

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       balVersion:
-        default: 2201.9.2
+        default: 2201.13.0
 jobs:
   test_macos:
     name: Test action on MacOS
@@ -38,6 +38,6 @@ jobs:
       - uses: ballerina-platform/setup-ballerina@main
         name: Test the action.
         with:
-          version: nightly-2201.9.x
+          version: nightly-2201.13.x
       - run: bal version
       - run: bal run hello.bal

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       balVersion:
-        default: 2201.9.2
+        default: 2201.13.0
 jobs:
   test_linux:
     name: Test action on Ubuntu
@@ -38,6 +38,6 @@ jobs:
       - uses: ballerina-platform/setup-ballerina@main
         name: Test the action.
         with:
-          version: nightly-2201.9.x
+          version: nightly-2201.13.x
       - run: bal version
       - run: bal run hello.bal

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       balVersion:
-        default: 2201.9.2
+        default: 2201.13.0
 jobs:
   test_windows:
     name: Test action on Windows
@@ -39,6 +39,6 @@ jobs:
       - uses: ballerina-platform/setup-ballerina@main
         name: Test the action.
         with:
-          version: nightly-2201.9.x
+          version: nightly-2201.13.x
       - run: bal version
       - run: bal run hello.bal

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
         else
           BALLERINA_VERSION=${{ inputs.version }}
         fi
-        echo "::set-output name=version::$BALLERINA_VERSION"
+        echo "version=$BALLERINA_VERSION" >> $GITHUB_OUTPUT
         echo BALLERINA_VERSION=$BALLERINA_VERSION >> $GITHUB_ENV
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Cache Restore
       id: cache-dist
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: |
           ballerina-${{ steps.configure-version.outputs.version }}-*.*

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   version:
     description: "Ballerina Version"
     required: true
-    default: 2201.9.2
+    default: 2201.13.0
   github-token:
     description: 'GitHub token'
     default: ${{ github.token }}


### PR DESCRIPTION
## Purpose
> $subject

Fixes for:
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request addresses deprecations in GitHub Actions workflows and dependencies:

**Changes to `action.yml`:**
- Updates the composite action's `configure-version` step to use the current `$GITHUB_OUTPUT` mechanism instead of the deprecated `::set-output` command for exposing the computed Ballerina version
- Upgrades the `actions/cache` dependency from v3 to v5 in the Cache Restore step to use a supported version

These changes ensure the action complies with current GitHub Actions standards and maintains compatibility with future runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->